### PR TITLE
Make `authenticateWithBiometrics` public so as App can present it if needed

### DIFF
--- a/PasscodeLock/PasscodeLockViewController.swift
+++ b/PasscodeLock/PasscodeLockViewController.swift
@@ -91,7 +91,7 @@ public class PasscodeLockViewController: UIViewController, PasscodeLockTypeDeleg
     public override func viewDidAppear(animated: Bool) {
         super.viewDidAppear(animated)
         
-        if shouldTryToAuthenticateWithBiometrics {
+        if shouldTryToAuthenticateWithBiometrics && passcodeConfiguration.shouldRequestTouchIDImmediately {
         
             authenticateWithBiometrics()
         }
@@ -121,7 +121,9 @@ public class PasscodeLockViewController: UIViewController, PasscodeLockTypeDeleg
     
     public func appWillEnterForegroundHandler(notification: NSNotification) {
         
-        authenticateWithBiometrics()
+        if passcodeConfiguration.shouldRequestTouchIDImmediately {
+            authenticateWithBiometrics()
+        }
     }
     
     public func appDidEnterBackgroundHandler(notification: NSNotification) {
@@ -153,9 +155,9 @@ public class PasscodeLockViewController: UIViewController, PasscodeLockTypeDeleg
         passcodeLock.authenticateWithBiometrics()
     }
     
-    private func authenticateWithBiometrics() {
+    public func authenticateWithBiometrics() {
         
-        if passcodeConfiguration.shouldRequestTouchIDImmediately && passcodeLock.isTouchIDAllowed {
+        if passcodeLock.isTouchIDAllowed {
             
             passcodeLock.authenticateWithBiometrics()
         }


### PR DESCRIPTION
Some apps need to be able to request TouchID immediately which is served by a nice option in the library.
Furthermore, the nice thing with this library is that it can be easily extended for supporting more features.
One feature that we have added to our app is passcode expiry after a time period. For example user wants to leave app unlocked for 3 minutes.

In this case our flow is as follows:
1. When app moves to background
   - Passcode is presented
   - A splash view is being added
2. When app comes to foreground
   - We check if Passcode is expired
     - remove splash view
     - if not expired:
       - dismisss passcode view
       - `*`

So for `*` the issue is that by setting `shouldRequestTouchIDImmediately` to `true` it will display the TouchID alert and there is no easy way to dismiss it. Apple has introduced `LAContext().invalidate()` at iOS9, although the animation has to happen and the user sees a flickering/annoying animation.

So instead of this, it works better to leave `shouldRequestTouchIDImmediately` to `false` and call `authenticateWithBiometrics` in our apps' code if needed.

p.s: `passcodeConfiguration.shouldRequestTouchIDImmediately` has been moved out of `authenticateWithBiometrics` as it doesn't feel to be in the right context and also caused the above scenario to not work.
