### PR TITLE
Udpate passcode view on viewWillAppear

### DIFF
--- a/PasscodeLock/PasscodeLockViewController.swift
+++ b/PasscodeLock/PasscodeLockViewController.swift
@@ -82,10 +82,15 @@ public class PasscodeLockViewController: UIViewController, PasscodeLockTypeDeleg
     public override func viewDidLoad() {
         super.viewDidLoad()
         
-        updatePasscodeView()
         deleteSignButton?.enabled = false
         
         setupEvents()
+    }
+    
+    public override func viewWillAppear(animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        updatePasscodeView()
     }
     
     public override func viewDidAppear(animated: Bool) {


### PR DESCRIPTION
In our app we are giving an option so as user can toggle on/off the `isTouchIDAllowed` in the implementation of `PasscodeLockConfigurationType`.

So if the user changes the switch the `PasscodeLockViewController` will not update its view if it is already loaded.

I can't think of any implications to Apps that already implemented the lib.
