### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Originally created by [@yankodimitrov](https://github.com/yankodimitrov/SwiftPas
 <img src="https://raw.githubusercontent.com/yankodimitrov/SwiftPasscodeLock/master/passcode-lock.gif" height="386">
 
 ## Installation
-PasscodeLock requires Swift 2.0 and XCode 7
+PasscodeLock requires Swift 2.0 and Xcode 7
 
 ### [CocoaPods](http://cocoapods.org/)
 


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
