### PR TITLE
Made the value of reason in authenticateWithBiometrics injectable 

### DIFF
--- a/PasscodeLock/PasscodeLock/PasscodeLock.swift
+++ b/PasscodeLock/PasscodeLock/PasscodeLock.swift
@@ -68,7 +68,12 @@ public class PasscodeLock: PasscodeLockType {
         guard isTouchIDAllowed else { return }
         
         let context = LAContext()
-        let reason = localizedStringFor("PasscodeLockTouchIDReason", comment: "TouchID authentication reason")
+        let reason: String
+        if let configReason = configuration.touchIdReason {
+            reason = configReason
+        } else {
+            reason = localizedStringFor("PasscodeLockTouchIDReason", comment: "TouchID authentication reason")
+        }
 
         context.localizedFallbackTitle = localizedStringFor("PasscodeLockTouchIDButton", comment: "TouchID authentication fallback button")
         

--- a/PasscodeLock/Protocols/PasscodeLockConfigurationType.swift
+++ b/PasscodeLock/Protocols/PasscodeLockConfigurationType.swift
@@ -14,5 +14,6 @@ public protocol PasscodeLockConfigurationType {
     var passcodeLength: Int {get}
     var isTouchIDAllowed: Bool {get set}
     var shouldRequestTouchIDImmediately: Bool {get}
+    var touchIdReason: String? {get set}
     var maximumInccorectPasscodeAttempts: Int {get}
 }

--- a/PasscodeLockTests/Fakes/FakePasscodeLockConfiguration.swift
+++ b/PasscodeLockTests/Fakes/FakePasscodeLockConfiguration.swift
@@ -15,6 +15,7 @@ class FakePasscodeLockConfiguration: PasscodeLockConfigurationType {
     var isTouchIDAllowed = false
     let maximumInccorectPasscodeAttempts = 3
     let shouldRequestTouchIDImmediately = false
+    var touchIdReason: String? = nil
     
     init(repository: PasscodeRepositoryType) {
         


### PR DESCRIPTION
I've coded a potential solution to issue #20.  This solution leverages PasscodeLockConfigurationType to optionally pass a value leveraged by authenticateWithBiometrics.  If the value is not set in the implementation of the Configuration Type then the code falls back to the existing logic that uses the strings resource file.  
