### PR TITLE
Fixed a security issue

### DIFF
--- a/PasscodeLock/PasscodeLock/EnterPasscodeState.swift
+++ b/PasscodeLock/PasscodeLock/EnterPasscodeState.swift
@@ -17,7 +17,17 @@ struct EnterPasscodeState: PasscodeLockStateType {
     let isCancellableAction: Bool
     var isTouchIDAllowed = true
     
-    private var inccorectPasscodeAttempts = 0
+    static let incorrectPasscodeAttemptsKey = "incorrectPasscodeAttempts"
+    static var incorrectPasscodeAttempts: Int {
+        get {
+            return NSUserDefaults.standardUserDefaults().integerForKey(incorrectPasscodeAttemptsKey)
+        }
+        set {
+            NSUserDefaults.standardUserDefaults().setInteger(newValue, forKey: incorrectPasscodeAttemptsKey)
+        }
+    }
+    
+
     private var isNotificationSent = false
     
     init(allowCancellation: Bool = false) {
@@ -33,21 +43,25 @@ struct EnterPasscodeState: PasscodeLockStateType {
             return
         }
         
+        var incorrectPasscodeAttempts = EnterPasscodeState.incorrectPasscodeAttempts
         if passcode == currentPasscode {
             
             lock.delegate?.passcodeLockDidSucceed(lock)
-            
+            incorrectPasscodeAttempts = 0
         } else {
             
-            inccorectPasscodeAttempts += 1
+            incorrectPasscodeAttempts += 1
             
-            if inccorectPasscodeAttempts >= lock.configuration.maximumInccorectPasscodeAttempts {
+            if incorrectPasscodeAttempts >= lock.configuration.maximumInccorectPasscodeAttempts {
                 
                 postNotification()
+                incorrectPasscodeAttempts = 0
             }
             
             lock.delegate?.passcodeLockDidFail(lock)
         }
+        
+        EnterPasscodeState.incorrectPasscodeAttempts = incorrectPasscodeAttempts
     }
     
     private mutating func postNotification() {

--- a/PasscodeLock/PasscodeLock/PasscodeLock.swift
+++ b/PasscodeLock/PasscodeLock/PasscodeLock.swift
@@ -84,7 +84,7 @@ public class PasscodeLock: PasscodeLockType {
         dispatch_async(dispatch_get_main_queue()) {
             
             if success {
-                
+                EnterPasscodeState.incorrectPasscodeAttempts = 0
                 self.delegate?.passcodeLockDidSucceed(self)
             }
         }


### PR DESCRIPTION
Previously, `inccorectPasscodeAttempts` was reset to 0 after kill and restart. So an attacker can bypass the `maximumInccorectPasscodeAttempts` setting by killing and restarting the app after trying a different password again and again.
