### PR TITLE
Add touchIdReason to PasscodeLockConfiguration

### DIFF
--- a/PasscodeLockDemo/PasscodeLockConfiguration.swift
+++ b/PasscodeLockDemo/PasscodeLockConfiguration.swift
@@ -15,6 +15,7 @@ struct PasscodeLockConfiguration: PasscodeLockConfigurationType {
     let passcodeLength = 4
     var isTouchIDAllowed = true
     let shouldRequestTouchIDImmediately = true
+    var touchIdReason: String? = "Authenticate using Touch ID."
     let maximumInccorectPasscodeAttempts = -1
     
     init(repository: PasscodeRepositoryType) {


### PR DESCRIPTION
This is a great tool! Thanks for the contributions @velikanov and @yankodimitrov!

The demo target `PasscodeLockDemo` does not build directly after pulling down because `PasscodeLockConfiguration` did not contain a `touchIdReason` property, which is required by the `PasscodeLockConfigurationType` protocol.

This PR adds that property and now the demo project successfully builds and runs 😎.
