### PR TITLE
Add cancel option to LockState.EnterPasscode state

### DIFF
--- a/PasscodeLock/PasscodeLockPresenter.swift
+++ b/PasscodeLock/PasscodeLockPresenter.swift
@@ -37,7 +37,7 @@ public class PasscodeLockPresenter {
     }
 
     public convenience init(mainWindow window: UIWindow?, configuration: PasscodeLockConfigurationType) {
-        let passcodeLockVC = PasscodeLockViewController(state: .EnterPasscode, configuration: configuration)
+        let passcodeLockVC = PasscodeLockViewController(state: .EnterPasscode(allowCancellation: true), configuration: configuration)
         
         self.init(mainWindow: window, configuration: configuration, viewController: passcodeLockVC)
     }

--- a/PasscodeLock/PasscodeLockViewController.swift
+++ b/PasscodeLock/PasscodeLockViewController.swift
@@ -11,7 +11,7 @@ import UIKit
 public class PasscodeLockViewController: UIViewController, PasscodeLockTypeDelegate {
     
     public enum LockState {
-        case EnterPasscode
+        case EnterPasscode(allowCancellation: Bool)
         case SetPasscode
         case ChangePasscode
         case RemovePasscode
@@ -19,7 +19,7 @@ public class PasscodeLockViewController: UIViewController, PasscodeLockTypeDeleg
         func getState() -> PasscodeLockStateType {
             
             switch self {
-            case .EnterPasscode: return EnterPasscodeState()
+            case .EnterPasscode(let allowCancellation): return EnterPasscodeState(allowCancellation: allowCancellation)
             case .SetPasscode: return SetPasscodeState()
             case .ChangePasscode: return ChangePasscodeState()
             case .RemovePasscode: return EnterPasscodeState(allowCancellation: true)

--- a/PasscodeLockDemo/CustomPasscodeLockPresenter.swift
+++ b/PasscodeLockDemo/CustomPasscodeLockPresenter.swift
@@ -24,7 +24,7 @@ class CustomPasscodeLockPresenter: PasscodeLockPresenter {
         splashView = LockSplashView()
         
         // TIP: you can set your custom viewController that has added functionality in a custom .xib too
-        let passcodeLockVC = PasscodeLockViewController(state: .EnterPasscode, configuration: configuration)
+        let passcodeLockVC = PasscodeLockViewController(state: .EnterPasscode(allowCancellation: true), configuration: configuration)
         
         super.init(mainWindow: window, configuration: configuration, viewController: passcodeLockVC)
         


### PR DESCRIPTION
Our team would like the option to be able to cancel out of the `LockState.EnterPasscode` state.

I thought of a couple different ways to do this:
1. Set the default value for `isCancellableAction` on `EnterPasswordState` to `true`
2. Make `isCancellableAction` on `PasscodeLockStateType` settable
3. Add an associated value to `LockState.EnterPasscode` to allow for that state with or without a cancellable action.

While all options had their pros and cons, I felt that the most flexible way to do this was option (3). Keep in mind that this breaks backwards compatibility, so it may be a good idea to wait for the next major release to add this in, but of course, it's up to the owners of this repo.
